### PR TITLE
Add Gradle plugin enhancements and publishing improvements

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,8 +21,8 @@ jobs:
         with:
             run-ktlint: true
             run-tests: true
-    
-    publish-github:
+
+    publish-release:
         needs: ci-checks
         runs-on: ubuntu-latest
         steps:
@@ -50,15 +50,17 @@ jobs:
                       echo "Using manually provided version: ${{ github.event.inputs.version }}"
                       echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
                     fi
-            -   name: Publish to GitHub Packages
-                run: ./gradlew publishAllPublicationsToGitHubRepository -PreleaseVersion=$VERSION
+            -   name: Publish to GitHub Packages and Maven Central
+                run: ./gradlew publish -PreleaseVersion=$VERSION
                 env:
                     GITHUB_USERNAME: ${{ github.actor }}
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                     ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
                     ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-    
-    publish-maven:
+                    ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+                    ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+
+    publish-release-plugin:
         needs: ci-checks
         runs-on: ubuntu-latest
         steps:
@@ -86,10 +88,19 @@ jobs:
                       echo "Using manually provided version: ${{ github.event.inputs.version }}"
                       echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
                     fi
-            -   name: Publish to Maven Central
-                run: ./gradlew publishToMavenCentral -PreleaseVersion=$VERSION
+            -   name: Publish plugin to GitHub Packages
+                run: ./gradlew :gradle-plugin:publish -PreleaseVersion=$VERSION
                 env:
+                    GITHUB_USERNAME: ${{ github.actor }}
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                     ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
                     ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
                     ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
                     ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+            -   name: Publish plugin to Gradle Plugin Portal
+                run: ./gradlew :gradle-plugin:publishPlugins -PreleaseVersion=$VERSION
+                env:
+                    ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+                    ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+                    GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+                    GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -16,7 +16,7 @@ jobs:
         with:
             run-ktlint: true
             run-tests: true
-    
+
     publish-snapshot:
         needs: ci-checks
         runs-on: ubuntu-latest
@@ -33,7 +33,35 @@ jobs:
             -   name: Grant execute permission for gradlew
                 run: chmod +x gradlew
             -   name: Publish to GitHub Packages
-                run: ./gradlew publishAllPublicationsToGitHubRepository
+                run: ./gradlew publish
+                env:
+                    GITHUB_USERNAME: ${{ github.actor }}
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    publish-plugin-snapshot:
+        needs: ci-checks
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v3
+                with:
+                    fetch-depth: 0
+            -   name: Set up JDK
+                uses: actions/setup-java@v3
+                with:
+                    distribution: 'temurin'
+                    java-version: '21'
+                    cache: gradle
+            -   name: Grant execute permission for gradlew
+                run: chmod +x gradlew
+            -   name: Generate snapshot version
+                run: |
+                    COMMIT_SHA=$(git rev-parse --short HEAD)
+                    TIMESTAMP=$(date +%Y%m%d.%H%M%S)
+                    SNAPSHOT_VERSION="$TIMESTAMP-$COMMIT_SHA-SNAPSHOT"
+                    echo "SNAPSHOT_VERSION=$SNAPSHOT_VERSION" >> $GITHUB_ENV
+                    echo "Publishing plugin snapshot version: $SNAPSHOT_VERSION"
+            -   name: Publish plugin to GitHub Packages
+                run: ./gradlew :gradle-plugin:publish -PreleaseVersion=$SNAPSHOT_VERSION
                 env:
                     GITHUB_USERNAME: ${{ github.actor }}
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ grpc-kt is a protoc plugin for generating Kotlin data classes and gRPC service/s
 - **gRPC Service/Stub Code**: Generates Kotlin-friendly gRPC service and client code
 - **Flexible Service Implementation**: Supports both traditional (class-based) and functional interface approaches for implementing gRPC services
 - **Coroutines Support**: Uses Kotlin Coroutines for asynchronous operations and streaming
-- **Validation Support**: Compatible with Protocol Buffer validation rules
+- **Validation Support**: Compatible with Protocol Buffer validation rules via protoc-gen-validate
+- **Documentation Generation**: Automatically generates protocol buffer documentation
 - **Comprehensive Type Mapping**: Properly maps Protocol Buffer types to Kotlin types
+- **Gradle Plugin**: Simplifies project setup and configuration
 - **Support for Protocol Buffer Features**:
     - Oneofs (mapped to sealed interfaces)
     - Maps
@@ -23,21 +25,39 @@ grpc-kt is a protoc plugin for generating Kotlin data classes and gRPC service/s
 
 ## Project Structure
 
-grpc-kt consists of three main modules:
+grpc-kt consists of four main modules:
 
 - **common**: Provides runtime support for the generated code
-- **example**: Contains example proto files and usage
+- **example**: Contains example proto files and usage demonstrations
 - **generator**: The main code generation module (the protoc plugin)
+- **gradle-plugin**: A Gradle plugin that simplifies protobuf configuration
 
 ## Installation
 
 ### Gradle
 
-Add the following to your `build.gradle.kts` file:
-
 > **Note**: Artifacts are published to both GitHub Packages and Maven Central.
 > For GitHub Packages, you'll need to add the repository configuration.
 > Maven Central is the recommended source for public consumption.
+
+#### Option 1: Using the Gradle Plugin (Recommended)
+
+The easiest way to use grpc-kt is with the Gradle plugin, which automatically configures all dependencies and protobuf generation:
+
+```kotlin
+plugins {
+    kotlin("jvm") version "2.1.0"
+    id("io.github.imonja.grpc-kt-protobuf") version "1.1.0"
+}
+
+// The plugin automatically adds all necessary dependencies including grpc-kt-common
+```
+
+Place your `.proto` files in `proto/` directory in your project root (or `src/main/proto`).
+
+#### Option 2: Manual Configuration
+
+If you prefer manual configuration, add the following to your `build.gradle.kts` file:
 
 ```kotlin
 plugins {
@@ -331,6 +351,31 @@ This approach has several advantages:
 - Methods can be easily swapped or mocked for testing
 - Implementation can be provided as lambda functions or method references
 - No need to create a class that extends a base class
+
+## Gradle Plugin Configuration
+
+When using the Gradle plugin, you can customize the configuration:
+
+```kotlin
+grpcKtProtobuf {
+    sourceDir {
+        protoSourceDir.set("custom/proto/dir")  // Default: "${project.projectDir}/proto"
+    }
+    
+    generateSource {
+        grpcJavaOutputSubDir.set("java")        // Default: "java"
+        grpcKtOutputSubDir.set("kotlin")        // Default: "kotlin"
+        javaPgvOutputSubDir.set("java-pgv")     // Default: "java-pgv"
+        javaPgvLang.set("java")                 // Default: "java"
+    }
+    
+    docs {
+        grpcDocsFormat.set("markdown")          // Default: "markdown"
+        grpcDocsFileName.set("api-docs.md")     // Default: "grpc-docs.md"
+        grpcDocsOutputSubDir.set("docs")        // Default: "grpc-docs"
+    }
+}
+```
 
 ## Building from Source
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,9 +37,9 @@ subprojects {
     apply {
         plugin("java")
         plugin("org.jetbrains.kotlin.jvm")
+        plugin("org.jlleitschuh.gradle.ktlint")
         plugin("com.google.protobuf")
         plugin("maven-publish")
-        plugin("org.jlleitschuh.gradle.ktlint")
         plugin("signing")
         plugin("com.vanniktech.maven.publish")
     }
@@ -82,7 +82,6 @@ subprojects {
         useJUnitPlatform()
     }
 
-    // GitHub Packages publishing
     publishing {
         repositories {
             maven {
@@ -96,7 +95,7 @@ subprojects {
         }
     }
 
-    // Maven Central publishing configuration
+    // Maven Central publishing configuration - only for publishable modules
     configure<com.vanniktech.maven.publish.MavenPublishBaseExtension> {
         coordinates(
             groupId = project.group.toString(),
@@ -148,5 +147,16 @@ subprojects {
                 include("**/build/generated/**")
             }
         }
+    }
+}
+
+tasks.register("ktlintFormatAll") {
+    description = "Run ktlintFormat for all modules (grpc-kt, gradle-plugin)"
+    group = "formatting"
+    dependsOn("ktlintFormat")
+
+    doLast {
+        // Run ktlintFormat for gradle-plugin composite build
+        gradle.includedBuild("gradle-plugin").task(":ktlintFormat")
     }
 }

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -1,0 +1,63 @@
+# gRPC Kotlin Protobuf Gradle Plugin
+
+This is a Gradle plugin that encapsulates the protobuf configuration for gRPC Kotlin projects. It automatically configures protobuf generation with multiple generators including grpc-kt, grpc-java, validation, and documentation.
+
+## Usage
+
+To use this plugin in your project, add the following to your `build.gradle.kts`:
+
+```kotlin
+plugins {
+    id("io.github.imonja.grpc-kt-protobuf")
+}
+```
+
+## What it does
+
+The plugin automatically:
+
+1. **Applies required plugins**: `java` and `com.google.protobuf`
+2. **Adds dependencies**: All necessary gRPC, protobuf, and Kotlin coroutines dependencies
+3. **Configures protobuf generation** with multiple generators:
+   - `grpc-java`: Java gRPC code generation
+   - `grpc-kt`: Kotlin gRPC code generation (using the grpc-kt plugin)
+   - `java-pgv`: Protocol Buffer validation
+   - `grpc-docs`: Documentation generation
+4. **Configures source sets**: Adds generated source directories to the main source set
+5. **Versions**: Uses predefined versions for all dependencies
+
+## Proto files
+
+Place your `.proto` files in the `src/main/proto` directory (or `proto/` directory in project root).
+
+## Generated code
+
+The plugin generates code in the following directories:
+- Java gRPC code: `build/generated/source/proto/main/java`
+- Kotlin gRPC code: `build/generated/source/proto/main/kotlin`
+- Validation code: `build/generated/source/proto/main/java-pgv`
+- Documentation: `build/generated/source/proto/main/grpc-docs`
+
+## Dependencies added
+
+The plugin automatically adds the following dependencies:
+- `io.grpc:grpc-stub`
+- `io.grpc:grpc-protobuf`
+- `io.grpc:grpc-kotlin-stub`
+- `com.google.protobuf:protobuf-kotlin`
+- `com.google.protobuf:protobuf-java`
+- `com.google.protobuf:protobuf-java-util`
+- `build.buf.protoc-gen-validate:pgv-java-grpc`
+- `build.buf.protoc-gen-validate:pgv-java-stub`
+- `org.jetbrains.kotlinx:kotlinx-coroutines-core`
+
+## Version compatibility
+
+The plugin is designed to work with the grpc-kt project and uses version `1.1.0` of the grpc-kt protoc plugin.
+
+## Publishing
+
+When published to Maven Central, the plugin will be available as:
+- **Group ID**: `io.github.imonja`
+- **Artifact ID**: `gradle-plugin`
+- **Plugin ID**: `io.github.imonja.grpc-kt-protobuf`

--- a/gradle-plugin/settings.gradle.kts
+++ b/gradle-plugin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "gradle-plugin"

--- a/gradle-plugin/src/main/kotlin/io/github/imonja/grpc/kt/plugin/GrpcKtProtobufExtension.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/imonja/grpc/kt/plugin/GrpcKtProtobufExtension.kt
@@ -1,0 +1,65 @@
+package io.github.imonja.grpc.kt.plugin
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import javax.inject.Inject
+
+open class GrpcKtProtobufExtension @Inject constructor(
+    objects: ObjectFactory,
+    project: Project
+) {
+    val sourceDir: SourceDirConfiguration = objects.newInstance(SourceDirConfiguration::class.java, project)
+    val generateSource: GenerateSourceConfiguration = objects.newInstance(GenerateSourceConfiguration::class.java)
+    val docs: DocsConfiguration = objects.newInstance(DocsConfiguration::class.java)
+
+    fun sourceDir(action: Action<SourceDirConfiguration>) {
+        action.execute(sourceDir)
+    }
+
+    fun generateSource(action: Action<GenerateSourceConfiguration>) {
+        action.execute(generateSource)
+    }
+
+    fun docs(action: Action<DocsConfiguration>) {
+        action.execute(docs)
+    }
+}
+
+open class SourceDirConfiguration @Inject constructor(
+    objects: ObjectFactory,
+    project: Project
+) {
+    val protoSourceDir: Property<String> = objects.property(String::class.java)
+        .convention("${project.projectDir}/proto")
+}
+
+open class GenerateSourceConfiguration @Inject constructor(
+    objects: ObjectFactory
+) {
+    val grpcJavaOutputSubDir: Property<String> = objects.property(String::class.java)
+        .convention("java")
+
+    val grpcKtOutputSubDir: Property<String> = objects.property(String::class.java)
+        .convention("kotlin")
+
+    val javaPgvOutputSubDir: Property<String> = objects.property(String::class.java)
+        .convention("java-pgv")
+
+    val javaPgvLang: Property<String> = objects.property(String::class.java)
+        .convention("java")
+}
+
+open class DocsConfiguration @Inject constructor(
+    objects: ObjectFactory
+) {
+    val grpcDocsFormat: Property<String> = objects.property(String::class.java)
+        .convention("markdown")
+
+    val grpcDocsFileName: Property<String> = objects.property(String::class.java)
+        .convention("grpc-docs.md")
+
+    val grpcDocsOutputSubDir: Property<String> = objects.property(String::class.java)
+        .convention("grpc-docs")
+}

--- a/gradle-plugin/src/main/kotlin/io/github/imonja/grpc/kt/plugin/GrpcKtProtobufPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/imonja/grpc/kt/plugin/GrpcKtProtobufPlugin.kt
@@ -1,0 +1,146 @@
+package io.github.imonja.grpc.kt.plugin
+
+import com.google.protobuf.gradle.ProtobufPlugin
+import com.google.protobuf.gradle.id
+import com.google.protobuf.gradle.proto
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.dependencies
+
+class GrpcKtProtobufPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        // Apply required plugins
+        project.plugins.apply(JavaPlugin::class)
+        project.plugins.apply(ProtobufPlugin::class)
+
+        // Create the extension
+        val extension = project.extensions.create<GrpcKtProtobufExtension>("grpcKtProtobuf", project)
+
+        // Configure versions
+        val pgvVersion = "1.1.0"
+        val pgdVersion = "1.5.1"
+        val kotlinGrpcVersion = "1.4.1"
+        val javaGrpcVersion = "1.71.0"
+        val protobufVersion = "4.30.2"
+        val coroutinesVersion = "1.10.2"
+
+        // Add dependencies
+        project.dependencies {
+            add("implementation", "io.github.imonja:grpc-kt-common:${getPluginVersion()}")
+            add("implementation", "io.grpc:grpc-stub:$javaGrpcVersion")
+            add("implementation", "io.grpc:grpc-protobuf:$javaGrpcVersion")
+            add("implementation", "io.grpc:grpc-kotlin-stub:$kotlinGrpcVersion")
+            add("implementation", "com.google.protobuf:protobuf-kotlin:$protobufVersion")
+            add("implementation", "com.google.protobuf:protobuf-java:$protobufVersion")
+            add("implementation", "com.google.protobuf:protobuf-java-util:$protobufVersion")
+            add("implementation", "build.buf.protoc-gen-validate:pgv-java-grpc:$pgvVersion")
+            add("implementation", "build.buf.protoc-gen-validate:pgv-java-stub:$pgvVersion")
+            add("implementation", "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+        }
+
+        // Configure protobuf
+        project.configure<com.google.protobuf.gradle.ProtobufExtension> {
+            protoc {
+                artifact = "com.google.protobuf:protoc:$protobufVersion"
+            }
+
+            plugins {
+                id("grpc-java") {
+                    artifact = "io.grpc:protoc-gen-grpc-java:$javaGrpcVersion"
+                }
+                id("java-pgv") {
+                    artifact = "build.buf.protoc-gen-validate:protoc-gen-validate:$pgvVersion"
+                }
+                id("grpc-docs") {
+                    artifact = "io.github.pseudomuto:protoc-gen-doc:$pgdVersion"
+                }
+                id("grpc-kt") {
+                    // Check if we're in a multi-project build with a generator module
+                    val generatorProject = project.rootProject.findProject(":generator")
+                    if (generatorProject != null) {
+                        // Use a local generator jar for development
+                        path = "${project.rootDir}/generator/build/libs/generator-${project.rootProject.version}.jar"
+                    } else {
+                        // Use the published artifact with the same version as this plugin
+                        artifact = "io.github.imonja:protoc-gen-grpc-kt:${getPluginVersion()}:jdk8@jar"
+                    }
+                }
+            }
+            generateProtoTasks {
+                all().forEach {
+                    it.plugins {
+                        id("grpc-java") {
+                            outputSubDir = extension.generateSource.grpcJavaOutputSubDir.get()
+                        }
+                        id("grpc-kt") {
+                            outputSubDir = extension.generateSource.grpcKtOutputSubDir.get()
+                        }
+                        id("java-pgv") {
+                            option("lang=${extension.generateSource.javaPgvLang.get()}")
+                            outputSubDir = extension.generateSource.javaPgvOutputSubDir.get()
+                        }
+                        id("grpc-docs") {
+                            option(
+                                "${extension.docs.grpcDocsFormat.get()}, ${extension.docs.grpcDocsFileName.get()}"
+                            )
+                            outputSubDir = extension.docs.grpcDocsOutputSubDir.get()
+                        }
+                    }
+                }
+            }
+        }
+
+        // Configure sourceSets for proto files
+        project.afterEvaluate {
+            // Configure a proto source directory
+            val protoSourceDir = extension.sourceDir.protoSourceDir.get()
+            project.configure<org.gradle.api.tasks.SourceSetContainer> {
+                named("main") {
+                    java {
+                        srcDir(
+                            "${project.layout.buildDirectory.get()}/generated/source/proto/main/${
+                            extension.generateSource.grpcJavaOutputSubDir.get()
+                            }"
+                        )
+                        srcDir(
+                            "${project.layout.buildDirectory.get()}/generated/source/proto/main/${
+                            extension.generateSource.grpcKtOutputSubDir.get()
+                            }"
+                        )
+                        srcDir(
+                            "${project.layout.buildDirectory.get()}/generated/source/proto/main/${
+                            extension.generateSource.javaPgvOutputSubDir.get()
+                            }"
+                        )
+                    }
+                    proto {
+                        srcDir(protoSourceDir)
+                    }
+                }
+            }
+
+            // Add dependency on generator build if we're using local generator
+            val generatorProject = project.rootProject.findProject(":generator")
+            if (generatorProject != null) {
+                project.tasks.named("generateProto") {
+                    dependsOn("${generatorProject.path}:build")
+                }
+            }
+        }
+    }
+
+    private fun getPluginVersion(): String {
+        // Get version from plugin's resources or manifest
+        val pluginVersion = this::class.java.`package`.implementationVersion
+        return if (pluginVersion != null && pluginVersion != "unspecified") {
+            pluginVersion
+        } else {
+            // Fallback to reading from gradle.properties or default
+            "1.1.0"
+        }
+    }
+}

--- a/gradle-plugin/src/main/resources/META-INF/gradle-plugins/io.github.imonja.grpc-kt-gradle-plugin.properties
+++ b/gradle-plugin/src/main/resources/META-INF/gradle-plugins/io.github.imonja.grpc-kt-gradle-plugin.properties
@@ -1,0 +1,1 @@
+implementation-class=io.github.imonja.grpc.kt.plugin.GrpcKtProtobufPlugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project Information
-version=1.1.0-SNAPSHOT
+version=1.1.1-SNAPSHOT
 
 # Kotlin Configuration
 kotlin.code.style=official

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,3 +2,6 @@ rootProject.name = "grpc-kt"
 include("common")
 include("generator")
 include("example")
+
+// Include gradle-plugin as composite build for example module to use
+includeBuild("gradle-plugin")


### PR DESCRIPTION
```markdown
### Overview

This pull request makes significant updates and improvements to the Gradle plugin and its publishing setup:

- Enhanced publishing configuration for Maven Central, Gradle Plugin Portal, and GitHub.
- Added support for project-level configurations and improved dependency management.
- Introduced `GrpcKtProtobufExtension` to enable customizable protobuf configurations.
- Renamed the plugin to `grpc-kt-gradle-plugin` and updated associated metadata.
- Simplified Gradle workflows and consolidated publishing procedures.
- Enabled automatic release publishing for non-SNAPSHOT versions.

### Key Changes

- Modified and streamlined plugin publishing configurations.
- Refactored build scripts and removed redundant elements for clarity and maintainability.
- Added `ktlint` tasks for consistent code formatting.
- Improved default configurations and conventions for the plugin.

### Notes

These changes address the need for better usability, publishing workflows, and maintainability. Further steps may include additional testing for edge scenarios.
