### PR TITLE
Fix code generation and resolve port conflicts in tests

### DIFF
--- a/example/src/main/kotlin/com/example/AlternateServerExample.kt
+++ b/example/src/main/kotlin/com/example/AlternateServerExample.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 
 object PartialServerExample {
 
-    private const val SERVER_PORT = 50052
+    private val SERVER_PORT = (60000..65000).random()
 
     @JvmStatic
     fun main(args: Array<String>) {

--- a/example/src/test/kotlin/com/example/AlternateServerExampleTest.kt
+++ b/example/src/test/kotlin/com/example/AlternateServerExampleTest.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 
 class PartialServerExampleTest {
 
-    private val serverPort = 50053
+    private val serverPort = (60_000..65_000).random()
     private var server: io.grpc.Server? = null
     private var channel: io.grpc.ManagedChannel? = null
 
@@ -252,11 +252,11 @@ class PartialServerExampleTest {
         val method = PartialServerExample::class.java.getDeclaredMethod("demonstratePartialGrpcService")
         assert(method != null) { "demonstratePartialGrpcService method should exist" }
 
-        // Verify that the SERVER_PORT constant exists and has the expected value
+        // Verify that the SERVER_PORT constant exists and is in valid range
         val serverPortField = PartialServerExample::class.java.getDeclaredField("SERVER_PORT")
         serverPortField.isAccessible = true
         val serverPort = serverPortField.get(PartialServerExample) as Int
-        assert(serverPort == 50052) { "SERVER_PORT should be 50052" }
+        assert(serverPort in 60000..65000) { "SERVER_PORT should be in range 60000-65000, but was $serverPort" }
     }
 
     @Test

--- a/gradle-plugin/src/main/kotlin/io/github/imonja/grpc/kt/plugin/GrpcKtProtobufPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/imonja/grpc/kt/plugin/GrpcKtProtobufPlugin.kt
@@ -109,23 +109,6 @@ class GrpcKtProtobufPlugin : Plugin<Project> {
             val protoSourceDir = extension.sourceDir.protoSourceDir.get()
             project.configure<org.gradle.api.tasks.SourceSetContainer> {
                 named("main") {
-                    java {
-                        srcDir(
-                            "${project.layout.buildDirectory.get()}/generated/source/proto/main/${
-                            extension.generateSource.grpcJavaOutputSubDir.get()
-                            }"
-                        )
-                        srcDir(
-                            "${project.layout.buildDirectory.get()}/generated/source/proto/main/${
-                            extension.generateSource.grpcKtOutputSubDir.get()
-                            }"
-                        )
-                        srcDir(
-                            "${project.layout.buildDirectory.get()}/generated/source/proto/main/${
-                            extension.generateSource.javaPgvOutputSubDir.get()
-                            }"
-                        )
-                    }
                     proto {
                         srcDir(protoSourceDir)
                     }
@@ -150,7 +133,7 @@ class GrpcKtProtobufPlugin : Plugin<Project> {
             if (propertiesStream != null) {
                 val properties = java.util.Properties()
                 propertiesStream.use { properties.load(it) }
-                properties.getProperty("version", "1.1.0")
+                properties.getProperty("version", fallbackVersion)
             } else {
                 // Fallback to package implementation version
                 val packageVersion = this::class.java.`package`.implementationVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project Information
-version=1.1.2-SNAPSHOT
+version=1.1.6-SNAPSHOT
 
 # Kotlin Configuration
 kotlin.code.style=official


### PR DESCRIPTION
- Addressed mismatches in the `CodeBlock` template parameters within `ServerBuilderPartial`.
- Implemented random port allocation (60000-65000) to prevent port binding conflicts in tests.
- Removed redundant type casting by introducing the `@Suppress` annotation.
- Updated test assertions to align with the new random port allocation range.