### PR TITLE
Feature/add optional field support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,7 +135,10 @@ subprojects {
 
         // Only publish to Maven Central for non-SNAPSHOT versions
         if (!version.toString().contains("SNAPSHOT")) {
-            publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
+            publishToMavenCentral(
+                host = com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL,
+                automaticRelease = true
+            )
             signAllPublications()
         }
     }

--- a/example/proto/service.proto
+++ b/example/proto/service.proto
@@ -18,6 +18,7 @@ service PersonService {
     rpc UpdateContactInfo(UpdateContactInfoRequest) returns (UpdateContactInfoResponse) {}
     rpc UpdateNotificationSettings(UpdateNotificationSettingsRequest) returns (UpdateNotificationSettingsResponse) {}
     rpc GetSchedule(GetScheduleRequest) returns (GetScheduleResponse) {}
+    rpc TestOptionalField(TestOptionalFieldRequest) returns (TestOptionalFieldResponse) {}
 }
 
 message GetPersonRequest {
@@ -81,4 +82,11 @@ message GetScheduleResponse {
     }
     repeated ScheduleItem items = 1;
     google.protobuf.Timestamp when = 2;
+}
+
+message TestOptionalFieldRequest {
+    optional string field = 1;
+}
+message TestOptionalFieldResponse {
+    bool has_field = 1;
 }

--- a/example/proto/service.proto
+++ b/example/proto/service.proto
@@ -17,6 +17,7 @@ service PersonService {
     rpc ChatWithPerson(stream ChatRequest) returns (stream ChatResponse) {}
     rpc UpdateContactInfo(UpdateContactInfoRequest) returns (UpdateContactInfoResponse) {}
     rpc UpdateNotificationSettings(UpdateNotificationSettingsRequest) returns (UpdateNotificationSettingsResponse) {}
+    rpc GetSchedule(GetScheduleRequest) returns (GetScheduleResponse) {}
 }
 
 message GetPersonRequest {
@@ -24,7 +25,6 @@ message GetPersonRequest {
 }
 message GetPersonResponse {
     Person person = 1;
-    google.protobuf.Timestamp when = 2;
 }
 
 message DeletePersonRequest {
@@ -68,4 +68,17 @@ message UpdateNotificationSettingsRequest {
 message UpdateNotificationSettingsResponse {
     bool success = 1;
     string message = 2;
+}
+
+message GetScheduleRequest {
+    string person_id = 1;
+}
+message GetScheduleResponse {
+    message ScheduleItem {
+        string id = 1;
+        string title = 2;
+        string description = 3;
+    }
+    repeated ScheduleItem items = 1;
+    google.protobuf.Timestamp when = 2;
 }

--- a/example/src/main/kotlin/com/example/AlternateServerPartial.kt
+++ b/example/src/main/kotlin/com/example/AlternateServerPartial.kt
@@ -132,6 +132,30 @@ object PartialServerExample {
                 UpdateNotificationSettingsResponseKt(success = true, message = "Settings updated successfully")
             }
 
+        val getSchedule: PersonServiceGrpcPartialKt.GetScheduleGrpcMethod =
+            PersonServiceGrpcPartialKt.GetScheduleGrpcMethod { request ->
+                println("Partial server received getSchedule request for person: ${request.personId}")
+
+                // Create sample schedule items (now nested ScheduleItem type)
+                val scheduleItems = listOf(
+                    GetScheduleResponseKt.ScheduleItemKt(
+                        id = "schedule1",
+                        title = "Morning Meeting",
+                        description = "Team standup meeting with ${request.personId}"
+                    ),
+                    GetScheduleResponseKt.ScheduleItemKt(
+                        id = "schedule2",
+                        title = "Code Review",
+                        description = "Review pull request for Kotlin keywords feature"
+                    )
+                )
+
+                GetScheduleResponseKt(
+                    items = scheduleItems,
+                    `when` = java.time.LocalDateTime.now()
+                )
+            }
+
         // Create the service using the PartialServerBuilder
         val partialService = PersonServiceGrpcPartialKt.PersonServiceCoroutineImplPartial(
             getPerson = getPerson,
@@ -140,7 +164,8 @@ object PartialServerExample {
             updatePerson = updatePerson,
             chatWithPerson = chatWithPerson,
             updateContactInfo = updateContactInfo,
-            updateNotificationSettings = updateNotificationSettings
+            updateNotificationSettings = updateNotificationSettings,
+            getSchedule = getSchedule
         )
 
         // Start the gRPC server with the partial service
@@ -274,6 +299,17 @@ object PartialServerExample {
             val notificationResponse = stub.updateNotificationSettings(updateNotificationRequest)
             println("Notification settings update successful: ${notificationResponse.success}")
             println("Response message: ${notificationResponse.message}")
+
+            // Example 7: GetSchedule with Kotlin keyword field in response
+            println("\n--- Get Schedule Example (Kotlin keyword field) ---")
+            val getScheduleRequest = GetScheduleRequestKt(
+                personId = "person789"
+            )
+            val scheduleResponse = stub.getSchedule(getScheduleRequest)
+            println("Schedule response received at: ${scheduleResponse.`when`}")
+            scheduleResponse.items.forEach { item ->
+                println("Schedule item: ${item.id} - ${item.title}: ${item.description}")
+            }
         } finally {
             // Shutdown the channel and server
             println("\nShutting down partial client and server")

--- a/example/src/main/kotlin/com/example/AlternateServerPartial.kt
+++ b/example/src/main/kotlin/com/example/AlternateServerPartial.kt
@@ -156,6 +156,19 @@ object PartialServerExample {
                 )
             }
 
+        val testOptionalField: PersonServiceGrpcPartialKt.TestOptionalFieldGrpcMethod =
+            PersonServiceGrpcPartialKt.TestOptionalFieldGrpcMethod { request ->
+                println("Partial server received testOptionalField request")
+
+                // Check if the optional field is present using hasField() method
+                val hasField = request.hasField()
+                val fieldValue = if (hasField) request.field else "null"
+
+                println("Field present: $hasField, field value: '$fieldValue'")
+
+                TestOptionalFieldResponseKt(hasField = hasField)
+            }
+
         // Create the service using the PartialServerBuilder
         val partialService = PersonServiceGrpcPartialKt.PersonServiceCoroutineImplPartial(
             getPerson = getPerson,
@@ -165,7 +178,8 @@ object PartialServerExample {
             chatWithPerson = chatWithPerson,
             updateContactInfo = updateContactInfo,
             updateNotificationSettings = updateNotificationSettings,
-            getSchedule = getSchedule
+            getSchedule = getSchedule,
+            testOptionalField = testOptionalField
         )
 
         // Start the gRPC server with the partial service
@@ -310,6 +324,27 @@ object PartialServerExample {
             scheduleResponse.items.forEach { item ->
                 println("Schedule item: ${item.id} - ${item.title}: ${item.description}")
             }
+
+            // Example 8: TestOptionalField - Test optional field behavior
+            println("\n--- Test Optional Field Example ---")
+
+            // Test 1: Field not set
+            println("Test 1: Field not set")
+            val requestNoField = TestOptionalFieldRequestKt()
+            val responseNoField = stub.testOptionalField(requestNoField)
+            println("Has field: ${responseNoField.hasField}")
+
+            // Test 2: Field set to empty string
+            println("Test 2: Field set to empty string")
+            val requestEmptyField = TestOptionalFieldRequestKt(field = "")
+            val responseEmptyField = stub.testOptionalField(requestEmptyField)
+            println("Has field: ${responseEmptyField.hasField}")
+
+            // Test 3: Field set to "John"
+            println("Test 3: Field set to 'John'")
+            val requestWithField = TestOptionalFieldRequestKt(field = "John")
+            val responseWithField = stub.testOptionalField(requestWithField)
+            println("Has field: ${responseWithField.hasField}")
         } finally {
             // Shutdown the channel and server
             println("\nShutting down partial client and server")

--- a/example/src/main/kotlin/com/example/ProtoExample.kt
+++ b/example/src/main/kotlin/com/example/ProtoExample.kt
@@ -393,6 +393,27 @@ object ProtoExample {
                 println("Schedule item: ${item.id} - ${item.title}")
                 println("  Description: ${item.description}")
             }
+
+            // Example 8: TestOptionalField - Test optional field behavior
+            println("\n--- TestOptionalField Example ---")
+
+            // Test 1: Field not set
+            println("Test 1: Field not set")
+            val requestNoField = TestOptionalFieldRequestKt()
+            val responseNoField = stub.testOptionalField(requestNoField)
+            println("Has field: ${responseNoField.hasField}")
+
+            // Test 2: Field set to empty string
+            println("Test 2: Field set to empty string")
+            val requestEmptyField = TestOptionalFieldRequestKt(field = "")
+            val responseEmptyField = stub.testOptionalField(requestEmptyField)
+            println("Has field: ${responseEmptyField.hasField}")
+
+            // Test 3: Field set to "John"
+            println("Test 3: Field set to 'John'")
+            val requestWithField = TestOptionalFieldRequestKt(field = "John")
+            val responseWithField = stub.testOptionalField(requestWithField)
+            println("Has field: ${responseWithField.hasField}")
         } finally {
             // Shutdown the channel and server
             println("\nShutting down client and server")
@@ -520,6 +541,18 @@ object ProtoExample {
                 items = scheduleItems,
                 `when` = java.time.LocalDateTime.now() // Using backticks for Kotlin keyword
             )
+        }
+
+        override suspend fun testOptionalField(request: TestOptionalFieldRequestKt): TestOptionalFieldResponseKt {
+            println("Server received testOptionalField request")
+
+            // Check if the optional field is present using hasField() method
+            val hasField = request.hasField()
+            val fieldValue = if (hasField) request.field else "null"
+
+            println("Field present: $hasField, field value: '$fieldValue'")
+
+            return TestOptionalFieldResponseKt(hasField = hasField)
         }
     }
 }

--- a/example/src/main/kotlin/com/example/ProtoExample.kt
+++ b/example/src/main/kotlin/com/example/ProtoExample.kt
@@ -34,7 +34,10 @@ object ProtoExample {
         // Example 2: Oneof message examples
         demonstrateOneofMessages()
 
-        // Example 3: gRPC service interaction
+        // Example 3: Kotlin keywords demonstration
+        demonstrateKotlinKeywords()
+
+        // Example 4: gRPC service interaction
         demonstrateGrpcService()
 
         println("Proto Example completed")
@@ -207,6 +210,50 @@ object ProtoExample {
     }
 
     /**
+     * Demonstrates handling of Kotlin keywords in protobuf fields
+     */
+    private fun demonstrateKotlinKeywords() {
+        println("\n=== Kotlin Keywords Example ===")
+
+        // Create a schedule request (no longer has 'when' field)
+        val scheduleRequest = GetScheduleRequestKt(
+            personId = "user123"
+        )
+        println("Created schedule request: $scheduleRequest")
+        println("Person ID: ${scheduleRequest.personId}")
+
+        // Create a schedule item (now nested in response)
+        val scheduleItem = GetScheduleResponseKt.ScheduleItemKt(
+            id = "item1",
+            title = "Team Meeting",
+            description = "Weekly team sync"
+        )
+
+        // Create a schedule response with 'when' field (Kotlin keyword)
+        val scheduleResponse = GetScheduleResponseKt(
+            items = listOf(scheduleItem),
+            `when` = java.time.LocalDateTime.now() // Using backticks for Kotlin keyword
+        )
+        println("Created schedule response: $scheduleResponse")
+        println("Response timestamp (when field): ${scheduleResponse.`when`}")
+
+        // Demonstrate serialization/deserialization with Kotlin keywords
+        val requestJavaProto = scheduleRequest.toJavaProto()
+        val requestBytes = requestJavaProto.toByteArray()
+        val deserializedRequest = GetScheduleRequest.parseFrom(requestBytes).toKotlinProto()
+        println("Schedule request serialization works: ${scheduleRequest == deserializedRequest}")
+
+        val responseJavaProto = scheduleResponse.toJavaProto()
+        val responseBytes = responseJavaProto.toByteArray()
+        val deserializedResponse = GetScheduleResponse.parseFrom(responseBytes).toKotlinProto()
+        println("Schedule response serialization works: ${scheduleResponse == deserializedResponse}")
+
+        // Show how to check if field is set using generated helper functions
+        println("Person ID: '${scheduleRequest.personId}'")
+        println("Has timestamp when field set: ${scheduleResponse.hasWhen()}")
+    }
+
+    /**
      * Demonstrates how to use gRPC services with the generated code.
      */
     private fun demonstrateGrpcService() = runBlocking {
@@ -333,6 +380,19 @@ object ProtoExample {
             val notificationResponse = stub.updateNotificationSettings(updateNotificationRequest)
             println("Notification settings update successful: ${notificationResponse.success}")
             println("Response message: ${notificationResponse.message}")
+
+            // Example 7: GetSchedule with Kotlin keyword field in response
+            println("\n--- GetSchedule Example (Kotlin keywords) ---")
+            val getScheduleRequest = GetScheduleRequestKt(
+                personId = "service789"
+            )
+            val scheduleResponse = stub.getSchedule(getScheduleRequest)
+            println("Schedule response received at: ${scheduleResponse.`when`}") // Using backticks for Kotlin keyword
+            println("Number of schedule items: ${scheduleResponse.items.size}")
+            scheduleResponse.items.forEach { item ->
+                println("Schedule item: ${item.id} - ${item.title}")
+                println("  Description: ${item.description}")
+            }
         } finally {
             // Shutdown the channel and server
             println("\nShutting down client and server")
@@ -437,6 +497,29 @@ object ProtoExample {
             )
 
             return UpdateNotificationSettingsResponseKt(success = true, message = "Notification settings updated successfully")
+        }
+
+        override suspend fun getSchedule(request: GetScheduleRequestKt): GetScheduleResponseKt {
+            println("Server received getSchedule request for person: ${request.personId}")
+
+            // Create sample schedule items (now nested ScheduleItem type)
+            val scheduleItems = listOf(
+                GetScheduleResponseKt.ScheduleItemKt(
+                    id = "meeting1",
+                    title = "Product Planning",
+                    description = "Quarterly product roadmap discussion"
+                ),
+                GetScheduleResponseKt.ScheduleItemKt(
+                    id = "break1",
+                    title = "Coffee Break",
+                    description = "Team coffee break"
+                )
+            )
+
+            return GetScheduleResponseKt(
+                items = scheduleItems,
+                `when` = java.time.LocalDateTime.now() // Using backticks for Kotlin keyword
+            )
         }
     }
 }

--- a/example/src/test/kotlin/com/example/AlternateServerPartialTest.kt
+++ b/example/src/test/kotlin/com/example/AlternateServerPartialTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 
 class PartialServerExampleTest {
@@ -99,6 +100,30 @@ class PartialServerExampleTest {
                 UpdateNotificationSettingsResponseKt(success = true, message = "Test settings updated")
             }
 
+        val getSchedule: PersonServiceGrpcPartialKt.GetScheduleGrpcMethod =
+            PersonServiceGrpcPartialKt.GetScheduleGrpcMethod { request ->
+                println("Test server received getSchedule request for person: ${request.personId}")
+
+                // Create sample schedule items (now nested ScheduleItem type)
+                val scheduleItems = listOf(
+                    GetScheduleResponseKt.ScheduleItemKt(
+                        id = "test_schedule1",
+                        title = "Test Meeting",
+                        description = "Test meeting description"
+                    ),
+                    GetScheduleResponseKt.ScheduleItemKt(
+                        id = "test_schedule2",
+                        title = "Test Review",
+                        description = "Test code review session"
+                    )
+                )
+
+                GetScheduleResponseKt(
+                    items = scheduleItems,
+                    `when` = LocalDateTime.now() // Using backticks for Kotlin keyword
+                )
+            }
+
         // Create the service using the PartialServerBuilder
         val partialService = PersonServiceGrpcPartialKt.PersonServiceCoroutineImplPartial(
             getPerson = getPerson,
@@ -107,7 +132,8 @@ class PartialServerExampleTest {
             updatePerson = updatePerson,
             chatWithPerson = chatWithPerson,
             updateContactInfo = updateContactInfo,
-            updateNotificationSettings = updateNotificationSettings
+            updateNotificationSettings = updateNotificationSettings,
+            getSchedule = getSchedule
         )
 
         // Start the gRPC server with the partial service
@@ -397,6 +423,34 @@ class PartialServerExampleTest {
     }
 
     @Test
+    fun `test getSchedule with Kotlin keywords`() = runBlocking {
+        // Create a client stub
+        val stub = PersonServiceGrpcKt.PersonServiceCoroutineStub(channel!!)
+
+        // Create request (no longer has 'when' field)
+        val request = GetScheduleRequestKt(
+            personId = "test_person_789"
+        )
+
+        val response = stub.getSchedule(request)
+
+        // Verify response has items and timestamp (with Kotlin keyword field)
+        assert(response.items.isNotEmpty()) { "Expected schedule items in response" }
+        assert(response.`when` != null) { "Expected timestamp in response using Kotlin keyword 'when'" }
+
+        // Verify item properties (now nested ScheduleItem type)
+        val firstItem = response.items.first()
+        assert(firstItem.id.isNotEmpty()) { "Expected schedule item to have ID" }
+        assert(firstItem.title.isNotEmpty()) { "Expected schedule item to have title" }
+        assert(firstItem.description.isNotEmpty()) { "Expected schedule item to have description" }
+
+        // Verify we got the expected test data
+        assert(response.items.size == 2) { "Expected 2 schedule items" }
+        assert(firstItem.id == "test_schedule1") { "Expected first item ID to be 'test_schedule1'" }
+        assert(firstItem.title == "Test Meeting") { "Expected first item title to be 'Test Meeting'" }
+    }
+
+    @Test
     fun `test structure of PartialServerExample`() {
         // This test verifies the structure of the PartialServerExample without making gRPC calls
 
@@ -448,13 +502,34 @@ class PartialServerExampleTest {
                 }
             }
 
+        val updateContactInfo: PersonServiceGrpcPartialKt.UpdateContactInfoGrpcMethod =
+            PersonServiceGrpcPartialKt.UpdateContactInfoGrpcMethod { request ->
+                UpdateContactInfoResponseKt(success = true)
+            }
+
+        val updateNotificationSettings: PersonServiceGrpcPartialKt.UpdateNotificationSettingsGrpcMethod =
+            PersonServiceGrpcPartialKt.UpdateNotificationSettingsGrpcMethod { request ->
+                UpdateNotificationSettingsResponseKt(success = true, message = "Test")
+            }
+
+        val getSchedule: PersonServiceGrpcPartialKt.GetScheduleGrpcMethod =
+            PersonServiceGrpcPartialKt.GetScheduleGrpcMethod { request ->
+                GetScheduleResponseKt(
+                    items = listOf(),
+                    `when` = LocalDateTime.now()
+                )
+            }
+
         // Create the service using the PartialServerBuilder
         val partialService = PersonServiceGrpcPartialKt.PersonServiceCoroutineImplPartial(
             getPerson = getPerson,
             deletePerson = deletePerson,
             listPersons = listPersons,
             updatePerson = updatePerson,
-            chatWithPerson = chatWithPerson
+            chatWithPerson = chatWithPerson,
+            updateContactInfo = updateContactInfo,
+            updateNotificationSettings = updateNotificationSettings,
+            getSchedule = getSchedule
         )
 
         // Verify that the service was created successfully
@@ -495,13 +570,34 @@ class PartialServerExampleTest {
                 }
             }
 
+        val updateContactInfo: PersonServiceGrpcPartialKt.UpdateContactInfoGrpcMethod =
+            PersonServiceGrpcPartialKt.UpdateContactInfoGrpcMethod { request ->
+                UpdateContactInfoResponseKt(success = true)
+            }
+
+        val updateNotificationSettings: PersonServiceGrpcPartialKt.UpdateNotificationSettingsGrpcMethod =
+            PersonServiceGrpcPartialKt.UpdateNotificationSettingsGrpcMethod { request ->
+                UpdateNotificationSettingsResponseKt(success = true, message = "Test")
+            }
+
+        val getSchedule: PersonServiceGrpcPartialKt.GetScheduleGrpcMethod =
+            PersonServiceGrpcPartialKt.GetScheduleGrpcMethod { request ->
+                GetScheduleResponseKt(
+                    items = listOf(),
+                    `when` = LocalDateTime.now()
+                )
+            }
+
         // Create the service using the PartialServerBuilder
         val partialService = PersonServiceGrpcPartialKt.PersonServiceCoroutineImplPartial(
             getPerson = getPerson,
             deletePerson = deletePerson,
             listPersons = listPersons,
             updatePerson = updatePerson,
-            chatWithPerson = chatWithPerson
+            chatWithPerson = chatWithPerson,
+            updateContactInfo = updateContactInfo,
+            updateNotificationSettings = updateNotificationSettings,
+            getSchedule = getSchedule
         )
 
         // Start the gRPC server with the partial service
@@ -567,13 +663,34 @@ class PartialServerExampleTest {
                 flow { }
             }
 
+        val updateContactInfo: PersonServiceGrpcPartialKt.UpdateContactInfoGrpcMethod =
+            PersonServiceGrpcPartialKt.UpdateContactInfoGrpcMethod { request ->
+                UpdateContactInfoResponseKt(success = true)
+            }
+
+        val updateNotificationSettings: PersonServiceGrpcPartialKt.UpdateNotificationSettingsGrpcMethod =
+            PersonServiceGrpcPartialKt.UpdateNotificationSettingsGrpcMethod { request ->
+                UpdateNotificationSettingsResponseKt(success = true, message = "Test")
+            }
+
+        val getSchedule: PersonServiceGrpcPartialKt.GetScheduleGrpcMethod =
+            PersonServiceGrpcPartialKt.GetScheduleGrpcMethod { request ->
+                GetScheduleResponseKt(
+                    items = listOf(),
+                    `when` = LocalDateTime.now()
+                )
+            }
+
         // Create the service using the PartialServerBuilder
         val partialService = PersonServiceGrpcPartialKt.PersonServiceCoroutineImplPartial(
             getPerson = getPerson,
             deletePerson = deletePerson,
             listPersons = listPersons,
             updatePerson = updatePerson,
-            chatWithPerson = chatWithPerson
+            chatWithPerson = chatWithPerson,
+            updateContactInfo = updateContactInfo,
+            updateNotificationSettings = updateNotificationSettings,
+            getSchedule = getSchedule
         )
 
         // Start the gRPC server with the partial service

--- a/example/src/test/kotlin/com/example/AlternateServerPartialTest.kt
+++ b/example/src/test/kotlin/com/example/AlternateServerPartialTest.kt
@@ -124,6 +124,19 @@ class PartialServerExampleTest {
                 )
             }
 
+        val testOptionalField: PersonServiceGrpcPartialKt.TestOptionalFieldGrpcMethod =
+            PersonServiceGrpcPartialKt.TestOptionalFieldGrpcMethod { request ->
+                println("Test server received testOptionalField request")
+
+                // Check if the optional field is present using hasField() method
+                val hasField = request.hasField()
+                val fieldValue = if (hasField) request.field else "null"
+
+                println("Test server - Field present: $hasField, field value: '$fieldValue'")
+
+                TestOptionalFieldResponseKt(hasField = hasField)
+            }
+
         // Create the service using the PartialServerBuilder
         val partialService = PersonServiceGrpcPartialKt.PersonServiceCoroutineImplPartial(
             getPerson = getPerson,
@@ -133,7 +146,8 @@ class PartialServerExampleTest {
             chatWithPerson = chatWithPerson,
             updateContactInfo = updateContactInfo,
             updateNotificationSettings = updateNotificationSettings,
-            getSchedule = getSchedule
+            getSchedule = getSchedule,
+            testOptionalField = testOptionalField
         )
 
         // Start the gRPC server with the partial service
@@ -520,6 +534,11 @@ class PartialServerExampleTest {
                 )
             }
 
+        val testOptionalField: PersonServiceGrpcPartialKt.TestOptionalFieldGrpcMethod =
+            PersonServiceGrpcPartialKt.TestOptionalFieldGrpcMethod { request ->
+                TestOptionalFieldResponseKt(hasField = request.hasField())
+            }
+
         // Create the service using the PartialServerBuilder
         val partialService = PersonServiceGrpcPartialKt.PersonServiceCoroutineImplPartial(
             getPerson = getPerson,
@@ -529,7 +548,8 @@ class PartialServerExampleTest {
             chatWithPerson = chatWithPerson,
             updateContactInfo = updateContactInfo,
             updateNotificationSettings = updateNotificationSettings,
-            getSchedule = getSchedule
+            getSchedule = getSchedule,
+            testOptionalField = testOptionalField
         )
 
         // Verify that the service was created successfully
@@ -588,6 +608,11 @@ class PartialServerExampleTest {
                 )
             }
 
+        val testOptionalField: PersonServiceGrpcPartialKt.TestOptionalFieldGrpcMethod =
+            PersonServiceGrpcPartialKt.TestOptionalFieldGrpcMethod { request ->
+                TestOptionalFieldResponseKt(hasField = request.hasField())
+            }
+
         // Create the service using the PartialServerBuilder
         val partialService = PersonServiceGrpcPartialKt.PersonServiceCoroutineImplPartial(
             getPerson = getPerson,
@@ -597,7 +622,8 @@ class PartialServerExampleTest {
             chatWithPerson = chatWithPerson,
             updateContactInfo = updateContactInfo,
             updateNotificationSettings = updateNotificationSettings,
-            getSchedule = getSchedule
+            getSchedule = getSchedule,
+            testOptionalField = testOptionalField
         )
 
         // Start the gRPC server with the partial service
@@ -681,6 +707,11 @@ class PartialServerExampleTest {
                 )
             }
 
+        val testOptionalField: PersonServiceGrpcPartialKt.TestOptionalFieldGrpcMethod =
+            PersonServiceGrpcPartialKt.TestOptionalFieldGrpcMethod { request ->
+                TestOptionalFieldResponseKt(hasField = request.hasField())
+            }
+
         // Create the service using the PartialServerBuilder
         val partialService = PersonServiceGrpcPartialKt.PersonServiceCoroutineImplPartial(
             getPerson = getPerson,
@@ -690,7 +721,8 @@ class PartialServerExampleTest {
             chatWithPerson = chatWithPerson,
             updateContactInfo = updateContactInfo,
             updateNotificationSettings = updateNotificationSettings,
-            getSchedule = getSchedule
+            getSchedule = getSchedule,
+            testOptionalField = testOptionalField
         )
 
         // Start the gRPC server with the partial service
@@ -750,5 +782,80 @@ class PartialServerExampleTest {
             e.printStackTrace()
             assert(false) { "Exception during direct use of PartialServerExample: ${e.message}" }
         }
+    }
+
+    @Test
+    fun `test TestOptionalField - field not set`() = runBlocking {
+        // Create a client stub
+        val stub = PersonServiceGrpcKt.PersonServiceCoroutineStub(channel!!)
+
+        // Test scenario 1: Field NOT set
+        println("Testing TestOptionalField - field not set")
+        val request = TestOptionalFieldRequestKt()
+        val response = stub.testOptionalField(request)
+
+        // Should return false for hasField when field is not set
+        assert(!response.hasField) { "Expected hasField to be false when field is not set" }
+        println("✓ Field not set test passed: hasField = ${response.hasField}")
+    }
+
+    @Test
+    fun `test TestOptionalField - field set to empty string`() = runBlocking {
+        // Create a client stub
+        val stub = PersonServiceGrpcKt.PersonServiceCoroutineStub(channel!!)
+
+        // Test scenario 2: Field SET to empty string
+        println("Testing TestOptionalField - field set to empty string")
+        val request = TestOptionalFieldRequestKt(field = "")
+        val response = stub.testOptionalField(request)
+
+        // Should return true for hasField when field is set to empty string
+        assert(response.hasField) { "Expected hasField to be true when field is set to empty string" }
+        println("✓ Field set to empty string test passed: hasField = ${response.hasField}")
+    }
+
+    @Test
+    fun `test TestOptionalField - field set to John`() = runBlocking {
+        // Create a client stub
+        val stub = PersonServiceGrpcKt.PersonServiceCoroutineStub(channel!!)
+
+        // Test scenario 3: Field SET to "John"
+        println("Testing TestOptionalField - field set to 'John'")
+        val request = TestOptionalFieldRequestKt(field = "John")
+        val response = stub.testOptionalField(request)
+
+        // Should return true for hasField when field is set to "John"
+        assert(response.hasField) { "Expected hasField to be true when field is set to 'John'" }
+        println("✓ Field set to 'John' test passed: hasField = ${response.hasField}")
+    }
+
+    @Test
+    fun `test TestOptionalField - comprehensive scenarios`() = runBlocking {
+        // Create a client stub
+        val stub = PersonServiceGrpcKt.PersonServiceCoroutineStub(channel!!)
+
+        println("\n=== Comprehensive TestOptionalField Tests ===")
+
+        // Test various scenarios
+        val testCases = listOf(
+            Triple("Field not set", TestOptionalFieldRequestKt(), false),
+            Triple("Field set to empty string", TestOptionalFieldRequestKt(field = ""), true),
+            Triple("Field set to 'John'", TestOptionalFieldRequestKt(field = "John"), true),
+            Triple("Field set to whitespace", TestOptionalFieldRequestKt(field = " "), true),
+            Triple("Field set to null string", TestOptionalFieldRequestKt(field = "null"), true),
+            Triple("Field set to long string", TestOptionalFieldRequestKt(field = "This is a very long string to test"), true)
+        )
+
+        testCases.forEach { (description, request, expectedHasField) ->
+            println("\nTesting: $description")
+            val response = stub.testOptionalField(request)
+
+            assert(response.hasField == expectedHasField) { "Expected hasField to be $expectedHasField for case: $description" }
+
+            val fieldValue = if (request.hasField()) request.field else "<not set>"
+            println("✓ $description: hasField = ${response.hasField}, field value = '$fieldValue'")
+        }
+
+        println("\n=== All comprehensive tests passed! ===")
     }
 }

--- a/example/src/test/kotlin/com/example/ProtoExampleTest.kt
+++ b/example/src/test/kotlin/com/example/ProtoExampleTest.kt
@@ -463,6 +463,132 @@ class ProtoExampleTest {
         assert(firstItem.description.isNotEmpty()) { "Expected schedule item to have description" }
     }
 
+    @Test
+    fun `test TestOptionalField - field not set`() = runBlocking {
+        // Create a client stub
+        val stub = PersonServiceGrpcKt.PersonServiceCoroutineStub(channel!!)
+
+        // Test scenario 1: Field NOT set
+        println("Testing TestOptionalField - field not set")
+        val request = TestOptionalFieldRequestKt()
+        val response = stub.testOptionalField(request)
+
+        // Should return false for hasField when field is not set
+        assert(!response.hasField) { "Expected hasField to be false when field is not set" }
+        println("✓ Field not set test passed: hasField = ${response.hasField}")
+    }
+
+    @Test
+    fun `test TestOptionalField - field set to empty string`() = runBlocking {
+        // Create a client stub
+        val stub = PersonServiceGrpcKt.PersonServiceCoroutineStub(channel!!)
+
+        // Test scenario 2: Field SET to empty string
+        println("Testing TestOptionalField - field set to empty string")
+        val request = TestOptionalFieldRequestKt(field = "")
+        val response = stub.testOptionalField(request)
+
+        // Should return true for hasField when field is set to empty string
+        assert(response.hasField) { "Expected hasField to be true when field is set to empty string" }
+        println("✓ Field set to empty string test passed: hasField = ${response.hasField}")
+    }
+
+    @Test
+    fun `test TestOptionalField - field set to John`() = runBlocking {
+        // Create a client stub
+        val stub = PersonServiceGrpcKt.PersonServiceCoroutineStub(channel!!)
+
+        // Test scenario 3: Field SET to "John"
+        println("Testing TestOptionalField - field set to 'John'")
+        val request = TestOptionalFieldRequestKt(field = "John")
+        val response = stub.testOptionalField(request)
+
+        // Should return true for hasField when field is set to "John"
+        assert(response.hasField) { "Expected hasField to be true when field is set to 'John'" }
+        println("✓ Field set to 'John' test passed: hasField = ${response.hasField}")
+    }
+
+    @Test
+    fun `test TestOptionalField - comprehensive scenarios`() = runBlocking {
+        // Create a client stub
+        val stub = PersonServiceGrpcKt.PersonServiceCoroutineStub(channel!!)
+
+        println("\n=== Comprehensive TestOptionalField Tests ===")
+
+        // Test various scenarios
+        val testCases = listOf(
+            Triple("Field not set", TestOptionalFieldRequestKt(), false),
+            Triple("Field set to empty string", TestOptionalFieldRequestKt(field = ""), true),
+            Triple("Field set to 'John'", TestOptionalFieldRequestKt(field = "John"), true),
+            Triple("Field set to whitespace", TestOptionalFieldRequestKt(field = " "), true),
+            Triple("Field set to null string", TestOptionalFieldRequestKt(field = "null"), true),
+            Triple("Field set to long string", TestOptionalFieldRequestKt(field = "This is a very long string to test"), true)
+        )
+
+        testCases.forEach { (description, request, expectedHasField) ->
+            println("\nTesting: $description")
+            val response = stub.testOptionalField(request)
+
+            assert(response.hasField == expectedHasField) { "Expected hasField to be $expectedHasField for case: $description" }
+
+            val fieldValue = if (request.hasField()) request.field else "<not set>"
+            println("✓ $description: hasField = ${response.hasField}, field value = '$fieldValue'")
+        }
+
+        println("\n=== All comprehensive tests passed! ===")
+    }
+
+    @Test
+    fun `test TestOptionalField serialization`() {
+        // Test serialization/deserialization of TestOptionalFieldRequest with optional field
+
+        // Test case 1: Field not set
+        val requestNoField = TestOptionalFieldRequestKt()
+        val javaProtoNoField = requestNoField.toJavaProto()
+        val bytesNoField = javaProtoNoField.toByteArray()
+        val deserializedNoField = TestOptionalFieldRequest.parseFrom(bytesNoField).toKotlinProto()
+
+        assert(requestNoField == deserializedNoField) { "Request with no field should serialize correctly" }
+        assert(!deserializedNoField.hasField()) { "Deserialized request should not have field set" }
+
+        // Test case 2: Field set to empty string
+        val requestEmptyField = TestOptionalFieldRequestKt(field = "")
+        val javaProtoEmptyField = requestEmptyField.toJavaProto()
+        val bytesEmptyField = javaProtoEmptyField.toByteArray()
+        val deserializedEmptyField = TestOptionalFieldRequest.parseFrom(bytesEmptyField).toKotlinProto()
+
+        assert(requestEmptyField == deserializedEmptyField) { "Request with empty field should serialize correctly" }
+        assert(deserializedEmptyField.hasField()) { "Deserialized request should have field set" }
+        assert(deserializedEmptyField.field == "") { "Deserialized field should be empty string" }
+
+        // Test case 3: Field set to "John"
+        val requestWithField = TestOptionalFieldRequestKt(field = "John")
+        val javaProtoWithField = requestWithField.toJavaProto()
+        val bytesWithField = javaProtoWithField.toByteArray()
+        val deserializedWithField = TestOptionalFieldRequest.parseFrom(bytesWithField).toKotlinProto()
+
+        assert(requestWithField == deserializedWithField) { "Request with field should serialize correctly" }
+        assert(deserializedWithField.hasField()) { "Deserialized request should have field set" }
+        assert(deserializedWithField.field == "John") { "Deserialized field should be 'John'" }
+
+        // Test TestOptionalFieldResponse
+        val responseTrue = TestOptionalFieldResponseKt(hasField = true)
+        val javaProtoResponseTrue = responseTrue.toJavaProto()
+        val bytesResponseTrue = javaProtoResponseTrue.toByteArray()
+        val deserializedResponseTrue = TestOptionalFieldResponse.parseFrom(bytesResponseTrue).toKotlinProto()
+
+        assert(responseTrue == deserializedResponseTrue) { "Response with true should serialize correctly" }
+        assert(deserializedResponseTrue.hasField) { "Deserialized response should have hasField true" }
+
+        val responseFalse = TestOptionalFieldResponseKt(hasField = false)
+        val javaProtoResponseFalse = responseFalse.toJavaProto()
+        val bytesResponseFalse = javaProtoResponseFalse.toByteArray()
+        val deserializedResponseFalse = TestOptionalFieldResponse.parseFrom(bytesResponseFalse).toKotlinProto()
+
+        assert(responseFalse == deserializedResponseFalse) { "Response with false should serialize correctly" }
+        assert(!deserializedResponseFalse.hasField) { "Deserialized response should have hasField false" }
+    }
+
     /**
      * Implementation of the PersonService for testing.
      */
@@ -552,6 +678,18 @@ class ProtoExampleTest {
                 items = scheduleItems,
                 `when` = LocalDateTime.now() // Using backticks for Kotlin keyword
             )
+        }
+
+        override suspend fun testOptionalField(request: TestOptionalFieldRequestKt): TestOptionalFieldResponseKt {
+            println("Test server received testOptionalField request")
+
+            // Check if the optional field is present using hasField() method
+            val hasField = request.hasField()
+            val fieldValue = if (hasField) request.field else "null"
+
+            println("Test server - Field present: $hasField, field value: '$fieldValue'")
+
+            return TestOptionalFieldResponseKt(hasField = hasField)
         }
     }
 }

--- a/generator/src/main/kotlin/io/github/imonja/grpc/kt/builder/function/impl/FieldCheckFunctionsBuilder.kt
+++ b/generator/src/main/kotlin/io/github/imonja/grpc/kt/builder/function/impl/FieldCheckFunctionsBuilder.kt
@@ -2,6 +2,7 @@ package io.github.imonja.grpc.kt.builder.function.impl
 
 import com.google.protobuf.Descriptors.Descriptor
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.PropertySpec
 import io.github.imonja.grpc.kt.builder.function.FunctionSpecsBuilder
 import io.github.imonja.grpc.kt.toolkit.import.FunSpecsWithImports
 import io.github.imonja.grpc.kt.toolkit.import.Import
@@ -35,12 +36,12 @@ class FieldCheckFunctionsBuilder : FunctionSpecsBuilder<Descriptor> {
 
             if (field.isProtoOptional) {
                 val fieldName = field.jsonName
-                val methodName = "has${fieldName.capitalize()}"
+                val methodName = "has${fieldName.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }}"
 
                 val methodBuilder = FunSpec.builder(methodName)
                     .receiver(generatedType)
                     .returns(Boolean::class)
-                    .addStatement("return this.%L != null", normalizeFieldName(fieldName))
+                    .addStatement("return this.%N != null", PropertySpec.builder(fieldName, String::class).build())
 
                 if (field.isExplicitlyOptional) {
                     methodBuilder.addKdoc("Checks if the explicitly optional field [%L] was set.", fieldName)
@@ -61,26 +62,5 @@ class FieldCheckFunctionsBuilder : FunctionSpecsBuilder<Descriptor> {
         }
 
         return FunSpecsWithImports(funSpecs, imports)
-    }
-
-    // TODO: refactoring this sometimes
-    val kotlinKeywords = setOf(
-        "as", "break", "class", "continue", "do", "else", "false", "for",
-        "fun", "if", "in", "interface", "is", "null", "object", "package",
-        "return", "super", "this", "throw", "true", "try", "typealias",
-        "typeof", "val", "var", "when", "while", "by", "catch", "constructor",
-        "delegate", "dynamic", "field", "file", "finally", "get", "import",
-        "init", "param", "property", "receiver", "set", "setparam", "where",
-        "actual", "abstract", "annotation", "companion", "const", "crossinline",
-        "data", "enum", "expect", "external", "final", "infix", "inline",
-        "inner", "internal", "lateinit", "noinline", "open", "operator",
-        "out", "override", "private", "protected", "public", "reified",
-        "sealed", "suspend", "tailrec", "vararg"
-    )
-
-    fun normalizeFieldName(fieldName: String): String = if (fieldName in kotlinKeywords) {
-        "`$fieldName`"
-    } else {
-        fieldName
     }
 }


### PR DESCRIPTION
This pull request introduces new gRPC methods and messages to handle schedule retrieval and optional field testing, along with updates to Kotlin code and tests to support these changes. The most important changes include additions to the protobuf definitions, integration of new methods in the server implementation, and corresponding test cases.

### Protobuf updates:
* Added `GetSchedule` and `TestOptionalField` RPC methods to the `PersonService` definition in `example/proto/service.proto`. These methods handle schedule retrieval and optional field testing, respectively.
* Introduced new message types: `GetScheduleRequest`, `GetScheduleResponse` (with nested `ScheduleItem`), `TestOptionalFieldRequest`, and `TestOptionalFieldResponse`. These messages define the structure of requests and responses for the new methods.

### Server implementation updates:
* Added `getSchedule` and `testOptionalField` methods to the `PartialServerExample` object in `example/src/main/kotlin/com/example/AlternateServerPartial.kt`. These methods handle the logic for the new RPCs, including processing requests and generating responses. [[1]](diffhunk://#diff-9511f0d2ed6ef31398571faff52aa11acedf14a20c1970292c5b1e7e8a1e3d9dR135-R171) [[2]](diffhunk://#diff-9511f0d2ed6ef31398571faff52aa11acedf14a20c1970292c5b1e7e8a1e3d9dR316-R347)
* Updated the partial server builder to include the new methods.

### Kotlin keyword handling:
* Demonstrated handling of Kotlin keywords in protobuf fields, including serialization/deserialization and usage of backticks for reserved keywords like `when`. This is showcased in the `demonstrateKotlinKeywords` method in `ProtoExample`.

### Test updates:
* Added tests for `getSchedule` and `testOptionalField` RPC methods in `PartialServerExampleTest`. These tests verify the correctness of responses, including handling of optional fields and nested message types. [[1]](diffhunk://#diff-b7d67b5e4202bab76aa12397639a10f5954e657ca5fd66503d7c7f722c533df6R439-R466) [[2]](diffhunk://#diff-b7d67b5e4202bab76aa12397639a10f5954e657ca5fd66503d7c7f722c533df6R519-R552)
* Renamed test files and updated imports to reflect changes in the server implementation. [[1]](diffhunk://#diff-b7d67b5e4202bab76aa12397639a10f5954e657ca5fd66503d7c7f722c533df6R14) [[2]](diffhunk://#diff-b7d67b5e4202bab76aa12397639a10f5954e657ca5fd66503d7c7f722c533df6R103-R139)